### PR TITLE
Fix typos so that skeleton compiles

### DIFF
--- a/skeleton/Front.tex
+++ b/skeleton/Front.tex
@@ -1,4 +1,4 @@
-\dissaccpetance			% Required
+\dissacceptance			% Required
 \copyrightpage[...]{...}		% Optional, comment out or delete if undesired
 \libraryrights				% Required
 
@@ -8,7 +8,7 @@
 
 \begin{layabstract}{...}	% Replace the ... with the list of keywords
 % Lay abstract text here, either typed in directly or included using an `\input{}' command
-\end{abstract}
+\end{layabstract}
 
 % The optional preface, dedication, and acknowledgements environments are included similar to the abstract environment
 


### PR DESCRIPTION
Just a few changes to Front.tex so that the example compiles with pdflatex.
