### PR TITLE
Listof Conflict Resolution

### DIFF
--- a/maine-thesis.cls
+++ b/maine-thesis.cls
@@ -834,7 +834,7 @@
 	\fi
 }
 
-\newenvironment{listof}[1]{%
+\newenvironment{thesislist}[1]{%
 	\chapter*{LIST OF \texorpdfstring{\MakeUppercase{#1}}{#1}}
 	\addcontentsline{toc}{chapter}{{\listname\ \texorpdfstring{\MakeUppercase{#1}}{#1}}}
 	\ifnum\value{part}>1


### PR DESCRIPTION
Naming this environment 'listof' creates conflicts with the package 'float' used for improved figures and tables. By changing the name to something more unique, this conflict is resolved