### PR TITLE
Section Headings Justification

### DIFF
--- a/maine-thesis.cls
+++ b/maine-thesis.cls
@@ -450,7 +450,7 @@
 	%---Justified Decimal---
 	\newcommand*{\sectionstyle}{\bfseries}
 	\setlength{\sectionpost}{1.5ex \@plus .2ex}
-	\newcommand*{\subsectionstyle}{\hspace{0in}\bfseries}
+	\newcommand*{\subsectionstyle}{\bfseries}
 	\setlength{\subsectionpost}{.3ex \@plus .2ex}
 	\newcommand*{\subsubsectionstyle}{\bfseries}
 	\setlength{\subsubsectionpost}{.2ex \@plus .1ex}


### PR DESCRIPTION
Subsections were being (incorrectly) indented in the jdecimal (default)  heading mode. Fixed