### PR TITLE
Adjustment to TOC spacing to protect 5 leader dots

### DIFF
--- a/maine-thesis.cls
+++ b/maine-thesis.cls
@@ -855,7 +855,7 @@
 	{\rightskip\@tocrmarg}%
 	{\rightskip\@tocrmarg plus 4em \hyphenpenalty\@M}%
 	{%
-		\patchcmd{\@dottedtocline}{\hfill}{\hskip 8.4mm plus1fill}{\typeout{5-dot minimum leader patched}}{}%
+		\patchcmd{\@dottedtocline}{\hfill}{\hskip 9.3mm plus1fill}{\typeout{5-dot minimum leader patched}}{}%
 	}%
 	{\ClassErrorNoLine{maine-thesis}{Unable to patch \protect\@dottedtocline\MessageBreak 5-dot leader minimum will not be respected}}
 


### PR DESCRIPTION
Class was not respecting the 5 dot minimum in the TOC when chapter or appendix title was very close to the limit. 9.3mm appears to be the minimum to force this.