### PR TITLE
Skeleton Update to Reflect Thesislist Change

### DIFF
--- a/skeleton/Front.tex
+++ b/skeleton/Front.tex
@@ -28,9 +28,9 @@
 \listoffigures				% Include only if there are figures in the thesis
 
 % If you have other lists which need to be included they go here, possibly using the listof environment
-\begin{listof}{...}		% Replace the ... with name of the things being listed here
+\begin{thesislist}{...}		% Replace the ... with name of the things being listed here
 % Contents of list
-\end{listof}
+\end{thesislist}
 
 % Sets the document spacing and pagestyle.  It is recommended that the `bottom' option be used. 
 \mainmatter{bottom} 	


### PR DESCRIPTION
In the class file, "listof" was changed to "thesislist" in order to avoid conflict with the "float" package. This was reflected in the documentation files, but was previously missed in the skeleton document.